### PR TITLE
Getting the location of derivied functions

### DIFF
--- a/scripts/check-metadata-of-derived-functions.sh
+++ b/scripts/check-metadata-of-derived-functions.sh
@@ -8,13 +8,6 @@ METAUPDATER_PATH=$(dirname $0)/..
 RAICODE_PATH=$PWD
 echo "RAICODE_PATH: $RAICODE_PATH"
 
-# Check if Julia is installed and accessible
-if ! command -v julia >/dev/null 2>&1; then
-    echo "Error: Julia is not installed or not in your PATH." >&2
-    echo "Exiting with 0" >&2
-    exit 0
-fi
-
 julia --startup-file=no --history-file=no --project=$METAUPDATER_PATH -e "
     using Pkg
     Pkg.instantiate()

--- a/scripts/check-metadata-of-derived-functions.sh
+++ b/scripts/check-metadata-of-derived-functions.sh
@@ -8,6 +8,13 @@ METAUPDATER_PATH=$(dirname $0)/..
 RAICODE_PATH=$PWD
 echo "RAICODE_PATH: $RAICODE_PATH"
 
+# Check if Julia is installed and accessible
+if ! command -v julia >/dev/null 2>&1; then
+    echo "Error: Julia is not installed or not in your PATH." >&2
+    echo "Exiting with 0" >&2
+    exit 0
+fi
+
 julia --startup-file=no --history-file=no --project=$METAUPDATER_PATH -e "
     using Pkg
     Pkg.instantiate()

--- a/src/MetadataUpdater.jl
+++ b/src/MetadataUpdater.jl
@@ -9,6 +9,7 @@ struct DerivedFunctionSignature
     name::String
     version::String
     args_count::Integer
+    filename::String
 end
 
 mutable struct Env
@@ -18,7 +19,9 @@ mutable struct Env
     derived_functions::Vector{DerivedFunctionSignature}
     loc::Integer
 
-    Env(home_dir::String) = new(home_dir, 0, DerivedFunctionSignature[], 0)
+    current_file::String
+
+    Env(home_dir::String) = new(home_dir, 0, DerivedFunctionSignature[], 0, "")
     Env() = Env("")
 end
 
@@ -95,7 +98,7 @@ function shallow_walk(x::EXPR, env::Env)
                 function_name = fetch_value(fetch_value(x, :call, false), :quotenode, false).args[1].val
             end
 
-            sig = DerivedFunctionSignature(function_name, version, args_count)
+            sig = DerivedFunctionSignature(function_name, version, args_count, env.current_file)
             push!(env.derived_functions, sig)
         else
             # Function is preceded by `Salsa.@derived`
@@ -122,7 +125,7 @@ function shallow_walk(x::EXPR, env::Env)
                     function_name = fetch_value(fetch_value(x, :call, false), :quotenode, false).args[1].val
                 end
 
-                sig = DerivedFunctionSignature(function_name, version, args_count)
+                sig = DerivedFunctionSignature(function_name, version, args_count, env.current_file)
                 push!(env.derived_functions, sig)
             end
         end
@@ -153,15 +156,23 @@ end
 
 function fetch_metadatainfo_filenames(filenames::Vector{String}, env::Env=Env())
     for filename in filenames
+        env.current_file = filename
         fetch_metadatainfo_filename(filename, env)
     end
     return env
 end
 
 function fetch_metadatainfo_filename(filename::String, env::Env=Env())
-    should_file_name_be_skipped(filename) && return
+    if isdir(filename)
+        for file in readdir(filename)
+            fetch_metadatainfo_filename(joinpath(filename, file), env)
+        end
+        return env
+    end
+    should_file_name_be_skipped(filename) && return env
     env.files_count += 1
     content = open(io->read(io, String), filename)
+    env.current_file = filename
     fetch_metadatainfo_sourcecode(content, env)
     return env
 end


### PR DESCRIPTION
The following code gives the file where each derived function is defined:

```Julia
using MetadataUpdater
env = MetadataUpdater.fetch_metadatainfo_filename("/Users/alexandrebergel/Documents/RAI/raicode13") ;
MetadataUpdater.print_summary(env) ;

for df in env.derived_functions
   println("$(df.filename)\t$(df.name)")
end
```

Here is the full transcript: 

```
julia> using MetadataUpdater

julia> env = MetadataUpdater.fetch_metadatainfo_filename("/Users/alexandrebergel/Documents/RAI/raicode13") ;

julia> MetadataUpdater.print_summary(env) ;
┌ Info: Summary of the metadata extraction and comparison:
│     Analyzed loc = 356322
│     Number of analyzed files = 1620
└     Number of derived functions = 98

julia> for df in env.derived_functions
          println("$(df.filename)\t$(df.name)")
       end
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	value_arity
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	is_transient
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	layout_for_scc
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	_topo_sorted_blocks_in_scc
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	valid_idb_dependencies_for_decl
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	valid_dependencies_for_decl
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	_scc_for_def
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	_block_for_def
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	is_iterator
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	scc_recursion_type
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	is_scc_recursive
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/Execution.jl	fixpoint_value
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/collect-evaluation-environment.jl	_is_ivm_frame
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/collect-evaluation-environment.jl	_is_ivm_delta
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/collect-evaluation-environment.jl	_iter_atom_dependency
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/dc-inference.jl	_edb_materialized_cardinality_class
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/dc-inference.jl	_idb_materialized_cardinality_class
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/generic.jl	declaration_of
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-demand-transform.jl	scc_after_demand_transform
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-evaluability.jl	scc_after_evaluability
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-faqtorizer.jl	scc_after_faqtorizer
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-front.jl	scc_after_front
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-inlining.jl	scc_after_inlining
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-normalization.jl	scc_after_normalization
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-physical-opt.jl	scc_after_physical_opt
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-raivm.jl	block_after_raivm
/Users/alexandrebergel/Documents/RAI/raicode13/src/Execution/phase-recursion-rewrites.jl	scc_after_recursion_rewrites
/Users/alexandrebergel/Documents/RAI/raicode13/src/FDEnvironment/fd-environment.jl	_fds_for_block
/Users/alexandrebergel/Documents/RAI/raicode13/src/FFI/load-generic.jl	execute_staging_requests
/Users/alexandrebergel/Documents/RAI/raicode13/src/FFI/load-generic.jl	demand_staged_reqs
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/decl.jl	is_inline
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/decl.jl	is_outline
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/decl.jl	memoized_has_bound_decl
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/decl.jl	memoized_complete_bounds_by_name
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/def-dependency-graph.jl	_front_scc_for_id_naming_specialize
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/def-dependency-graph.jl	_front_scc_for_id_outline
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/def-dependency-graph.jl	_decl_ids_by_shape_closure
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/driver.jl	_staging_info_by_src
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/driver.jl	memoized_phase_problems_after_parse
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/driver.jl	memoized_phase_problems_default
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	memoized_parsed_problems
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	memoized_parsed_decls
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	docstring_name_index
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	docstring_id_index
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	eager_decls
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	source_name_index
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	range_index
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	generated_declaration_at_load
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	generated_origin_at_load
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	decl_index
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	memoized_parsed_decl
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	namespace_declares
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/eager-maintainers.jl	decls_for_context_id
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/external-utils.jl	source_names
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	memoized_parsed_decl_ids
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	should_run_phase_staging
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	compile_front_scc_after_staging
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	should_run_phase_outline
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	compile_front_scc_after_outline
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	compile_front_scc_after_type_inference
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	compile_back
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	memoized_this_or_earlier_phase
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	attempt_to_compile_after_phase
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	memoized_should_compile_after_phase
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/phases.jl	compile_front_inner
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	bound_schema
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	namespace_path
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	underconstrained_natives
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	orig_name
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_memoized_generated_ids_for_id_at_parse
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_memoized_generated_ids_for_id
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_dependencies_for_id
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	transitive_irreflexive_scc_dependencies_for_id
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_decl_shape_trie
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_shape_term
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_source_id_attrs
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_lookup_edbs_from_decl_ids
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_use_decl_shape_trie
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_decl_ids_by_shape
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	memoized_has_fatal_error
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	declared_attributes
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	_decls_for_signature
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/salsa.jl	signatures_for_id
/Users/alexandrebergel/Documents/RAI/raicode13/src/FrontCompiler/versions.jl	_db_lang_version
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/edb.jl	is_edb
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/edb.jl	edb_signatures_for_name
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/edb.jl	_empty_bound_info
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/edb.jl	edb_is_empty
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/rel_config.jl	cardinality_estimation_disabled
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/rel_config.jl	ivm_verification_enabled
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/rel_config.jl	bound_separate_compilation_enabled
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/rel_config.jl	staging_analysis_enabled
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/rel_config.jl	integrity_constraints_enabled
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/workspace.jl	_symbol_table
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/workspace.jl	all_edb_paths
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/workspace.jl	_edb_paths_by_name
/Users/alexandrebergel/Documents/RAI/raicode13/src/Metadata/workspace.jl	all_source_names
/Users/alexandrebergel/Documents/RAI/raicode13/src/RAIVM/utils.jl	has_double_frame

julia> 

```